### PR TITLE
Exit with a non-zero exit code if nothing is logged to STDERR.

### DIFF
--- a/src/automongobackup.sh
+++ b/src/automongobackup.sh
@@ -540,7 +540,10 @@ else
 fi
 
 # TODO: Would be nice to know if there were any *actual* errors in the $LOGERR
-STATUS=1
+STATUS=0
+if [ -s "$LOGERR" ]; then
+  STATUS=1
+fi
 
 # Clean up Logfile
 eval rm -f "$LOGFILE"


### PR DESCRIPTION
A proper exit code is needed for monitoring of the success or failure of
the backup attempt by services like probyapp.com.

It is possible to get mongodump to not print to STDERR by making sure
that all options are configured correctly (for example, disabling
replication finding if not using replica sets).
