### PR TITLE
Support both debian and centos/redhat type config out-of-the-box

### DIFF
--- a/src/automongobackup.sh
+++ b/src/automongobackup.sh
@@ -29,8 +29,11 @@
 #=====================================================================
 
 # External config - override default values set below
-# EXTERNAL_CONFIG="/etc/default/automongobackup"	# debian style
-EXTERNAL_CONFIG="/etc/sysconfig/automongobackup"	# centos style
+if [ -f "/etc/default/automongobackup" ]; then 
+    EXTERNAL_CONFIG="/etc/default/automongobackup"	# debian style
+elif [ -f "/etc/sysconfig/automongobackup"]; then
+    EXTERNAL_CONFIG="/etc/sysconfig/automongobackup"	# centos style
+fi
 
 # Username to access the mongo server e.g. dbuser
 # Unnecessary if authentication is off


### PR DESCRIPTION
Added a simple if-exists check for the sysconfig files to include the one that is available. Having both in place allows using the script without having to modify it, which allows for easier syncing in case of changes. 
