### PR TITLE
Fail early on any error

### DIFF
--- a/src/automongobackup.sh
+++ b/src/automongobackup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 #
 # MongoDB Backup Script
 # VER. 0.20


### PR DESCRIPTION
Stop script running if any underlaying command exits with non zero status. You don't want crippled scripts running on your systems, potentially wreaking havoc