### PR TITLE
Exit if no frequency is set

### DIFF
--- a/src/automongobackup.sh
+++ b/src/automongobackup.sh
@@ -617,6 +617,13 @@ elif [[ $DOHOURLY = "yes" ]] ; then
 
 fi
 
+# FILE will not be set if no frequency is selected.
+if [[ -z "$FILE" ]] ; then
+  echo "ERROR: No backup frequency was chosen."
+  echo "Please set one of DOHOURLY,DODAILY,DOWEEKLY,DOMONTHLY to \"yes\"" 
+  exit 1
+fi
+
 dbdump "$FILE" && compression "$FILE"
 
 echo ----------------------------------------------------------------------


### PR DESCRIPTION
This was causing problems when someone tried to disable our backups.

The expected behaviour (no backups) didn't happen :(

Instead the script just backs up without FILE variable being set which
causes the mongodump to run into the the CWD which is worse. (we
filled our root partition which wasn't fun!)

So when FILE is not set, it will exit with non zero return code.
This seems like the best option as I assume that this script will often be
run from cron. Therefore a failed cron job will result in a message to say
that it failed. It's probably best to be bugged when backups are not
running as having no backup frequency set should really be an
exceptional config state.