### PR TITLE
Ignoring oplog option if partial dump requested

### DIFF
--- a/src/automongobackup.sh
+++ b/src/automongobackup.sh
@@ -341,7 +341,7 @@ if [ "$DBUSERNAME" ]; then
 fi
 
 # Do we use oplog for point-in-time snapshotting?
-if [ "$OPLOG" = "yes" ]; then
+if [ "$OPLOG" = "yes" ] && [ "$DBNAME" != "yes" ]; then
     OPT="$OPT --oplog"
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If DBNAME option is used, OPLOG param should be ignored since mongodb doesn't allow oplog unless it is a full dump and throws error
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/micahwedemeyer/automongobackup/issues/50
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by taking partial and complete backups on a mongodb installation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
