### PR TITLE
do not use oplog if db name is set

### DIFF
--- a/src/automongobackup.sh
+++ b/src/automongobackup.sh
@@ -341,7 +341,7 @@ if [ "$DBUSERNAME" ]; then
 fi
 
 # Do we use oplog for point-in-time snapshotting?
-if [ "$OPLOG" = "yes" ] && [ "$DBNAME" != "yes" ]; then
+if [ "$OPLOG" = "yes" ] && [ -z "$DBNAME" ]; then
     OPT="$OPT --oplog"
 fi
 


### PR DESCRIPTION

## Description
db name is used as a yes/no switch, but its supposed to be the actual db name. Therefore, check for null or empty string instead.

## Motivation and Context
Script currently fails if a database name is given.

## How Has This Been Tested?
Using Mongo 3.4, simply using a database name will trigger this. This fix (or setting oplog to false) makes it work again.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
